### PR TITLE
Removed deathcross from blacklist

### DIFF
--- a/list.json
+++ b/list.json
@@ -8,7 +8,6 @@
     {"account":"miti","reason":"","validator":"smartsteem"},
     {"account":"binance-trade","reason":"","validator":"smartsteem"},
     {"account":"spydo","reason":"","validator":"smartsteem"},
-    {"account":"deathcross","reason":"","validator":"smartsteem"},
     {"account":"steemit-bot","reason":"","validator":"smartsteem"},
     {"account":"elyas","reason":"","validator":"smartsteem"},
     {"account":"michael.thomale","reason":"","validator":"smartsteem"},


### PR DESCRIPTION
The user was previously added to the blacklist but changed up the content. Which is why the blacklist is no-longer applying to him.